### PR TITLE
Add Balena URL and upgrade Balena CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,11 @@ LABEL Description="Use the Balena CLI to perform actions"
 ## Install the standalone balena-cli package
 RUN apt-get update && apt-get install -y curl unzip
 
-WORKDIR  /app
+WORKDIR /app
 
 ## Download and Unzip Balena CLI
-RUN curl -O -sSL https://github.com/balena-io/balena-cli/releases/download/v14.3.0/balena-cli-v14.3.0-linux-x64-standalone.zip && \ 
-  unzip balena-cli-*-linux-x64-standalone.zip
+RUN curl -O -sSL https://github.com/balena-io/balena-cli/releases/download/v14.3.0/balena-cli-v14.5.2-linux-x64-standalone.zip && \ 
+unzip balena-cli-*-linux-x64-standalone.zip
 
 ## Copy Entrypoint
 COPY entrypoint.sh ./entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Continuously deliver your applications to [BalenaCloud](https://www.balena.io/).
 
 _Optional_: Provide a sub-path to the location for application being deployed to BalenaCloud. Defaults to the workspace root.
 
+### `balena_url`
+
+_Optional_: Provide the URL for the alternative environment.
+
 ### `balena_secrets`
 
 _Optional_: Provide the contents of a balena secrets.json file for authenticating against private registries.
@@ -46,6 +50,7 @@ jobs:
         with:
           balena_api_token: ${{secrets.BALENA_TOKEN}}
           balena_command: "push ${{secrets.BALENA_FLEET}} --logs"
+          balena_url: balena-staging.com
           balena_secrets: |
             {
               'ghcr.io': {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,10 +17,15 @@ if [[ "${INPUT_BALENA_API_TOKEN}" == "" ]]; then
   exit 1
 fi
 
+# Use Alternative environment if provided
+if [[ "${INPUT_BALENA_URL}" != "" ]]; then
+  echo "balenaUrl: '${INPUT_BALENA_URL}'" >~/.balenarc.yml
+fi
+
 # Write secrets file if provided
 if [[ "${INPUT_BALENA_SECRETS}" != "" ]]; then
   mkdir -p ~/.balena/
-  echo ${INPUT_BALENA_SECRETS} > ~/.balena/secrets.json
+  echo ${INPUT_BALENA_SECRETS} >~/.balena/secrets.json
 fi
 
 # Log in to Balena


### PR DESCRIPTION
1. Add the Staging URL option.
2. Update Balena CLI v14.5.2.

Documentation: https://www.balena.io/docs/learn/more/masterclasses/advanced-cli/#12-configuration-file