### PR TITLE
Changed to Balena CLI v22.2.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL Description="Use the Balena CLI to perform actions"
 ## CLI version
 ARG CLI_VERSION=22.2.4
 ARG CLI_URL=https://github.com/balena-io/balena-cli/releases/download/v${CLI_VERSION}
-ARG CLI_ARCHIVE=balena-cli-v${CLI_VERSION}-linux-x64-standalone.zip
+ARG CLI_ARCHIVE=balena-cli-v${CLI_VERSION}-linux-x64-standalone.tar.gz
 ARG DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /app
@@ -14,15 +14,14 @@ WORKDIR /app
 ## Install the standalone balena-cli package
 RUN apt update && \
     apt install -y \
-        curl \
-        unzip && \
+        curl && \
     apt autoremove -y && \
     rm -rf /var/lib/apt/lists/* && \
     apt clean
 
 ## Download and Unzip Balena CLI
 RUN curl -O -sSL ${CLI_URL}/${CLI_ARCHIVE} && \
-    unzip balena-cli-${CLI_ARCHIVE}-linux-x64-standalone.zip
+    tar -xvzf balena-cli-${CLI_ARCHIVE}-linux-x64-standalone.tar.gz
 
 ## Copy Entrypoint
 COPY entrypoint.sh ./entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,10 @@ RUN apt update && \
     rm -rf /var/lib/apt/lists/* && \
     apt clean
 
-## Download and Unzip Balena CLI
+## Download and extract Balena CLI
 RUN curl -O -sSL ${CLI_URL}/${CLI_ARCHIVE} && \
-    tar -xvzf ${CLI_ARCHIVE}
+    tar -xvzf ${CLI_ARCHIVE} && \
+    /app/balena/bin/balena --version
 
 ## Copy Entrypoint
 COPY entrypoint.sh ./entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apt update && \
 
 ## Download and Unzip Balena CLI
 RUN curl -O -sSL ${CLI_URL}/${CLI_ARCHIVE} && \
-    tar -xvzf balena-cli-${CLI_ARCHIVE}-linux-x64-standalone.tar.gz
+    tar -xvzf ${CLI_ARCHIVE}
 
 ## Copy Entrypoint
 COPY entrypoint.sh ./entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,28 @@
 FROM debian:stable-slim
 LABEL Description="Use the Balena CLI to perform actions"
 
-## Install the standalone balena-cli package
-RUN apt-get update && apt-get install -y curl unzip
+## Build arguments
+
+## CLI version
+ARG CLI_VERSION=22.2.4
+ARG CLI_URL=https://github.com/balena-io/balena-cli/releases/download/v${CLI_VERSION}
+ARG CLI_ARCHIVE=balena-cli-v${CLI_VERSION}-linux-x64-standalone.zip
+ARG DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /app
 
-## Version
-ENV CLI_VERSION=18.2.33
+## Install the standalone balena-cli package
+RUN apt update && \
+    apt install -y \
+        curl \
+        unzip && \
+    apt autoremove -y && \
+    rm -rf /var/lib/apt/lists/* && \
+    apt clean
 
 ## Download and Unzip Balena CLI
-RUN curl -O -sSL https://github.com/balena-io/balena-cli/releases/download/v${CLI_VERSION}/balena-cli-v${CLI_VERSION}-linux-x64-standalone.zip && \ 
-unzip balena-cli-*-linux-x64-standalone.zip
+RUN curl -O -sSL ${CLI_URL}/${CLI_ARCHIVE} && \
+    unzip balena-cli-${CLI_ARCHIVE}-linux-x64-standalone.zip
 
 ## Copy Entrypoint
 COPY entrypoint.sh ./entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,7 +29,7 @@ if [[ "${INPUT_BALENA_SECRETS}" != "" ]]; then
 fi
 
 # Log in to Balena
-/app/balena-cli/balena login --token "${INPUT_BALENA_API_TOKEN}"
+/app/balena/bin/balena login --token "${INPUT_BALENA_API_TOKEN}"
 
 # Run command
-/app/balena-cli/balena "$*"
+/app/balena/bin/balena "$*"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,12 +3,12 @@ set -e
 
 # Switch to Workspace path
 if [ -d "${GITHUB_WORKSPACE}" ]; then
-  cd ${GITHUB_WORKSPACE}
+  cd "${GITHUB_WORKSPACE}"
 fi
 
 # Switch to Application path
 if [ -d "${INPUT_APPLICATION_PATH}" ]; then
-  cd ${INPUT_APPLICATION_PATH}
+  cd "${INPUT_APPLICATION_PATH}"
 fi
 
 # Error out of no API Token is available
@@ -25,11 +25,11 @@ fi
 # Write secrets file if provided
 if [[ "${INPUT_BALENA_SECRETS}" != "" ]]; then
   mkdir -p ~/.balena/
-  echo ${INPUT_BALENA_SECRETS} >~/.balena/secrets.json
+  echo "${INPUT_BALENA_SECRETS}" >~/.balena/secrets.json
 fi
 
 # Log in to Balena
-/app/balena-cli/balena login --token ${INPUT_BALENA_API_TOKEN}
+/app/balena-cli/balena login --token "${INPUT_BALENA_API_TOKEN}"
 
 # Run command
-/app/balena-cli/balena $*
+/app/balena-cli/balena "$*"


### PR DESCRIPTION
Resolves #13.

This also fixes URLs and archive file names. It looks like Balena, Inc. has changed the build artifacts and no longer provides a ZIP for Linux.