### PR TITLE
Fixed push command

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,4 +32,4 @@ fi
 /app/balena/bin/balena login --token "${INPUT_BALENA_API_TOKEN}"
 
 # Run command
-/app/balena/bin/balena "$*"
+/app/balena/bin/balena $*


### PR DESCRIPTION
Removes double quotes because it is not a string but parameters.